### PR TITLE
Fix block name in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Be sure to install [prefect-sqlalchemy](#installation) and [save to block](#savi
         return all_rows
 
 
-    sqlalchemy_flow("BLOCK-NAME-PLACEHOLDER")
+    sqlalchemy_flow("BLOCK_NAME-PLACEHOLDER")
     ```
 
 === "Async"
@@ -143,7 +143,7 @@ Be sure to install [prefect-sqlalchemy](#installation) and [save to block](#savi
         return all_rows
 
 
-    asyncio.run(sqlalchemy_flow("BLOCK-NAME-PLACEHOLDER"))
+    asyncio.run(sqlalchemy_flow("BLOCK_NAME-PLACEHOLDER"))
     ```
 
 ## Resources


### PR DESCRIPTION
The block name is saved as `BLOCK_NAME-PLACEHOLDER`. But `sqlalchemy_flow()` was called with `BLOCK-NAME-PLACEHOLDER`. Converting all to `BLOCK_NAME-PLACEHOLDER`.

<!-- Thanks for contributing 🎉! Please ensure the title neatly summarizes the proposed changes. -->

<!-- Overview -->

Closes

### Example
<!-- A code blurb is best. Changes to features should include an example that is executable by a new user. -->

### Screenshots
<!--
Any relevant screenshots
  - The updated docs page from `mkdocs serve`.
  - Output from running the example.
  - Service integration test results.
-->

### Checklist
<!-- These boxes may be checked after opening the pull request. -->

- [ ] References any related issue by including "Closes #<Issue Number>" or "Closes <Issue URL>".
  - If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect-sqlalchemy/issues/new/choose) first.
- [ ] Includes tests or only affects documentation.
- [ ] Passes `pre-commit` checks.
  - Run `pre-commit install && pre-commit run --all` locally for formatting and linting.
- [ ] Includes screenshots of documentation updates.
  - Run `mkdocs serve` view documentation locally.
- [ ] Summarizes PR's changes in [CHANGELOG.md](https://github.com/PrefectHQ/prefect-sqlalchemy/blob/main/CHANGELOG.md)
